### PR TITLE
Fix lessc bootstrap build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(LESSC):
 
 bootstrap: $(LESSC)
 	git submodule update --init
-	$(LESSC) vendor/bootstrap/less/bootstrap.less > $(STATIC_DIRECTORY)/css/bootstrap.css
+	$(LESSC) vendor/bootstrap/less/bootstrap.less $(STATIC_DIRECTORY)/css/bootstrap.css
 	cp vendor/bootstrap/js/bootstrap-*.js $(STATIC_DIRECTORY)/javascript
 	cp vendor/bootstrap/img/* $(STATIC_DIRECTORY)/img
 


### PR DESCRIPTION
Bootstrap less compilation is silently failing. /static/mailviews/css/bootstrap.css ends up empty.

--

lessc uses `sys.print` to output CSS to stdout. `sys` is deprecated and no longer prints. So the output of the bootstrap CSS file was empty. Remove the `>` redirection of output from lessc and just specify an output file as the second argument to lessc.

--
> https://stackoverflow.com/a/64618105/193244
The sys module was renamed util with this commit dated Oct 12, 2010. So sys.puts() became util.puts(). util.puts() was added in v0.3.0, deprecation since v0.11.3, and removed in v12.0.0. The documentation advises to use console.log() instead.